### PR TITLE
Fix environment variables for process agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "surfkit"
-version = "0.1.218"
+version = "0.1.219"
 description = "A toolkit for building AI agents that use devices"
 authors = ["Patrick Barker <patrickbarkerco@gmail.com>"]
 license = "MIT"

--- a/surfkit/runtime/agent/process.py
+++ b/surfkit/runtime/agent/process.py
@@ -106,7 +106,7 @@ class ProcessAgentRuntime(AgentRuntime["ProcessAgentRuntime", ProcessConnectConf
 
         environment = os.environ.copy()
 
-        if not env_vars:
+        if env_vars:
             environment.update(env_vars)  # type: ignore
 
         environment["AGENT_TYPE"] = agent_type.to_v1().model_dump_json()


### PR DESCRIPTION
There was a typo and the environment variables were not being set in the process, causing `surfkit create agent -n robby001 -r process` (from the docs) to fail.