### PR TITLE
Minor - Remove fullstop (`.`) from the `No agents found.` message for…

### DIFF
--- a/surfkit/cli/main.py
+++ b/surfkit/cli/main.py
@@ -617,7 +617,7 @@ def list_agents(
         )
         print("")
     else:
-        print("No agents found.")
+        print("No agents found")
 
 
 @list_group.command("devices")


### PR DESCRIPTION
… consistency with other messages.

Also, `list_devices()` prints `No desktops found`. Why doesn't it say `No devices found` - are desktops the only type of devices possible?